### PR TITLE
Link to raw .jl files, rather than the github page

### DIFF
--- a/Fall20/cheatsheets/index.html
+++ b/Fall20/cheatsheets/index.html
@@ -55,7 +55,7 @@
 <!-- Content appended here -->
 <div class="franklin-content"><h1 id="cheatsheets"><a href="#cheatsheets">Cheatsheets</a></h1>
 <p>Check out the <a href="https://juliadocs.github.io/Julia-Cheat-Sheet/">Fastrack to Julia</a> cheatsheet.</p>
-<p>Below is a basic julia syntax cheatsheet in the form of a Pluto notebook <a href="https://github.com/mitmath/18S191/blob/master/lecture_notebooks/Basic&#37;20Julia&#37;20syntax.jl">&#40;right click for link you can paste into Pluto&#41;</a></p>
+<p>Below is a basic julia syntax cheatsheet in the form of a Pluto notebook <a href="https://raw.githubusercontent.com/mitmath/18S191/master/lecture_notebooks/Basic%20Julia%20syntax.jl">&#40;right click for link you can paste into Pluto&#41;</a></p>
 
 <iframe src="https://htmlpreview.github.io/?https://github.com/mitmath/18S191/blob/master/lecture_notebooks/Basic%20Julia%20syntax.html" width="100%"  height="1000px" frameborder="0"></iframe>
 

--- a/Fall20/hw0/index.html
+++ b/Fall20/hw0/index.html
@@ -63,7 +63,7 @@
 </li>
 <li><p><a href="https://htmlpreview.github.io/?https://github.com/mitmath/18S191/blob/master/homework/homework0/hw0.html">The Pluto notebook &#40;static view&#41;</a></p>
 </li>
-<li><p><a href="https://github.com/mitmath/18S191/blob/master/homework/homework0/hw0.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
+<li><p><a href="https://raw.githubusercontent.com/mitmath/18S191/master/homework/homework0/hw0.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
 </li>
 </ul>
 <div class="page-foot">

--- a/Fall20/hw1/index.html
+++ b/Fall20/hw1/index.html
@@ -57,7 +57,7 @@
 <p>Homeworks are in the form of Pluto notebooks. Your must complete them and submit them on Canvas &#40;if you are an MIT student.&#41;. If you are not an MIT student, we encourage you to join discord and find someone to cross-grade.</p>
 <p><strong>HW1 due date: Thursday, 10th Sep 2020 at 11:59pm EST</strong></p>
 <p><a href="https://htmlpreview.github.io/?https://github.com/mitmath/18S191/blob/master/homework/homework1/hw1.html">The Pluto notebook &#40;static view&#41;</a></p>
-<p><a href="https://github.com/mitmath/18S191/blob/master/homework/homework1/hw1.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
+<p><a href="https://raw.githubusercontent.com/mitmath/18S191/master/homework/homework1/hw1.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
 <div class="page-foot">
   <div class="copyright">
     Last modified: September 05, 2020. Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>.

--- a/hw0/index.html
+++ b/hw0/index.html
@@ -58,7 +58,7 @@
 </li>
 <li><p><a href="https://htmlpreview.github.io/?https://github.com/mitmath/18S191/blob/master/homework/homework0/hw0.html">The Pluto notebook &#40;static view&#41;</a></p>
 </li>
-<li><p><a href="https://github.com/mitmath/18S191/blob/master/homework/homework0/hw0.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
+<li><p><a href="https://raw.githubusercontent.com/mitmath/18S191/master/homework/homework0/hw0.jl">The Pluto notebook &#40;right click for link&#41;</a></p>
 </li>
 </ul>
 <div class="page-foot">


### PR DESCRIPTION
Otherwise, right-click + download will download the HTML showing the .jl file, not the .jl file itself.