### PR TITLE
Replace wrong notebook url on Lecture 3

### DIFF
--- a/website/lecture3.md
+++ b/website/lecture3.md
@@ -12,7 +12,7 @@ An application of the Sobel filter with an introduction to dynamic programming
 Pluto notebooks (right click to copy URL -- paste it into Pluto to open.)
 
 - Notebook 1 -- [Sobel as gradient](https://github.com/mitmath/18S191/blob/68e5631f5658d779482aa546f8d324ad2b426b27/lecture_notebooks/gradient.jl)
-- Notebook 2 -- [Seam carving](https://github.com/mitmath/18S191/blob/68e5631f5658d779482aa546f8d324ad2b426b27/lecture_notebooks/gradient.jl)
+- Notebook 2 -- [Seam carving](https://github.com/mitmath/18S191/blob/68e5631f5658d779482aa546f8d324ad2b426b27/lecture_notebooks/seam_carving.jl)
 
 {{youtube image-seam}}
 


### PR DESCRIPTION
On Lecture 3, there are two notebooks listed on the website: "Sobel as gradient" and "Seam carving". However, both of them are linked to lecture_notebooks/gradient.jl. This pull request replaces Seam carving's link with the right one.