### PR TITLE
Use `+` to match the surrounding cells

### DIFF
--- a/homework/homework5/hw5.jl
+++ b/homework/homework5/hw5.jl
@@ -225,8 +225,8 @@ We are able to make a `Coordinate` perform one random step, by adding a move to 
 Possible steps:
 - Use `rand(possible_moves, n)` to generate a vector of `n` random moves. Each possible move will be equally likely.
 - To compute the trajectory you can use either of the following two approaches:
-  1. 🆒 Use the function `accumulate` (see the live docs for `accumulate`). Use `move` as the function passed to `accumulate` and the `w` as the starting value (`init` keyword argument). 
-  1. Use a `for` loop calling `move`. 
+  1. 🆒 Use the function `accumulate` (see the live docs for `accumulate`). Use `+` as the function passed to `accumulate` and the `w` as the starting value (`init` keyword argument). 
+  1. Use a `for` loop calling `+`. 
 
 """
 


### PR DESCRIPTION
The previous cells said to overload Base.:+, this instruction should match that.