### PR TITLE
Cache exported static notebooks for faster builds

### DIFF
--- a/.github/workflows/ExportNotebooks.yml
+++ b/.github/workflows/ExportNotebooks.yml
@@ -12,6 +12,12 @@ jobs:
             - name: Checkout Spring 21 source
               uses: actions/checkout@v2
 
+            - name: Set up notebook state cache
+              uses: actions/cache@v2
+              with:
+                path: pluto_state_cache
+                key: ${{ runner.os }}-pluto_state_cache-v1-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
+
             - name: Checkout Fall 20 output
               uses: actions/checkout@v2
               with:
@@ -28,7 +34,7 @@ jobs:
                   Pkg.instantiate();
 
                   import PlutoUtils;
-                  PlutoUtils.Export.github_action(; export_dir=".", baked_state=false, offer_binder=true, binder_url="https://mybinder.org/build/gh/mitmath/18S191/e2dec90", bind_server_url="https://computationalthinking-sliderserver-do.plutojl.org");'
+                  PlutoUtils.Export.github_action(; export_dir=".", cache_dir="pluto_state_cache", baked_state=false, offer_binder=true, binder_url="https://mybinder.org/build/gh/mitmath/18S191/e2dec90", bind_server_url="https://computationalthinking-sliderserver-do.plutojl.org");'
             - name: Franklin
               run: julia -e '
                   using Pkg;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to **MIT 18.S191 aka 6.S083 aka 22.S092**, **Spring 2021** edition!
 _For older semester, see the [Fall 2020 branch](https://github.com/mitmath/18S191/tree/Fall20) or [older content](https://computationalthinking.mit.edu/Spring21/semesters/)._
 
 This is an introductory course on Computational Thinking. We use the [Julia programming language](http://www.julialang.org) to approach real-world problems in varied areas applying data analysis and computational and mathematical modeling. In this class you will learn computer science, software, algorithms, applications, and mathematics as an integrated whole.
- 
+
 Topics include:
 
 -   Image analysis

--- a/pluto-deployment-environment/Manifest.toml
+++ b/pluto-deployment-environment/Manifest.toml
@@ -179,8 +179,8 @@ version = "0.1.0"
 
 [[PlutoUtils]]
 deps = ["Base64", "GitHubActions", "HTTP", "Logging", "Pkg", "Pluto", "SHA", "Sockets"]
-git-tree-sha1 = "574e9c7e482ed576f77622375194e01d338e5ca3"
-repo-rev = "7e05465"
+git-tree-sha1 = "64642b321d59f48afc38c5a1bf6bb3117647d4d1"
+repo-rev = "8d361b9"
 repo-url = "https://github.com/fonsp/PlutoUtils.jl"
 uuid = "a5ec66cb-57bb-4ae5-9259-3342d9ed6c94"
 version = "0.1.0"


### PR DESCRIPTION
Using https://github.com/actions/cache to maintain a cache directory between builds, which is used by the Pluto export script to read and write statefiles, addressed by notebook file hash.

https://github.com/fonsp/PlutoUtils.jl/commit/ecafebf7796268d2334e09ea164cf3c8323076c8