### PR TITLE
It is the values field that needs a different type to handle vector ODEs

### DIFF
--- a/notebooks/week11/odes_and_parameterized_types.jl
+++ b/notebooks/week11/odes_and_parameterized_types.jl
@@ -570,7 +570,7 @@ end
 md"""
 However, it turns out that we then lose efficiency (speed). 
 
-What we would need is two different types: one in which we specify the type of `times` as `Vector{Float64}`, and the other as `Vector{Vector{Float64}}`.
+What we would need is two different types: one in which we specify the type of `values` as `Vector{Float64}`, and the other as `Vector{Vector{Float64}}`.
 
 Julia provides a mechanism to define *both at once*: this is what parameterized types do!
 """


### PR DESCRIPTION
The field that need to become of time Vector{Vector{Float64}} to deal with vector ODEs is the values field, not the times field. The times field can actually continue the same. 