### PR TITLE
Fix: Convert row->columns in hw4.jl

### DIFF
--- a/src/homework/hw4.jl
+++ b/src/homework/hw4.jl
@@ -239,7 +239,7 @@ Removing the seam `[1,1,1,1]` is equivalent to removing the first column:
 
 # ╔═╡ 6aeb2d1c-8585-4397-a05f-0b1e91baaf67
 md"""
-If we remove the same seam twice, we remove the first two rows:
+If we remove the same seam twice, we remove the first two columns:
 """
 
 # ╔═╡ 318a2256-f369-11ea-23a9-2f74c566549b


### PR DESCRIPTION
## Motivation

While working on Hw4, the caption seemed out of sync with the behavior.

From comparing the first and last image, we can see that the last image is made up of the last 2 columns of the first image. 

<img width="746" alt="image" src="https://github.com/user-attachments/assets/80dc41c3-be1e-4e64-95b5-ef814dbebf18">

We would need a `remove_in_each_column` function to remove the first 2 rows, the current function can only remove 1 item per row per pass.

The current behavior removes the first 2 `columns`, not `rows` .