### PR TITLE
Fix sign consistency in Newton method 2D code

### DIFF
--- a/src/images_abstractions/newton_method.jl
+++ b/src/images_abstractions/newton_method.jl
@@ -290,9 +290,9 @@ function newton2D_step(T, x)
 	
 	J = ForwardDiff.jacobian(T, x)   # should use StaticVectors
 	
-	δ = J \ T(x)   # J^(-1) * T(x)
-	
-	return x - δ
+	δ = J \ -T(x)   # J^(-1) * (-T(x))
+
+	return x + δ
 end
 
 # ╔═╡ 923bde64-7ba4-11eb-21e9-a11993aaab2e


### PR DESCRIPTION
Fixes #112

The Julia code for Newton's method in 2D (`newton2D_step`) used `δ = J \ T(x)` and `return x - δ`, while the LaTeX equations define `J · δ = -T(x₀)` and `x₁ = x₀ + δ`. The signs cancel so the computation was correct, but the mismatch is confusing for students.

Changed the code to match the equations:
- `δ = J \ -T(x)` (was `J \ T(x)`)
- `return x + δ` (was `x - δ`)