### PR TITLE
Fix broken Spring 2021 source code link and typo in alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to **MIT 18.C25 aka 6.C25**, **Fall 2024** edition!
 _For older semesters, see:
 - Fall 2023: [source code](https://github.com/mitmath/18S191/tree/Fall23) and [website](https://computationalthinking.mit.edu/Fall24/semesters/)
 - Fall 2022: [source code](https://github.com/mitmath/18S191/tree/Fall22) and [website](https://computationalthinking.mit.edu/Fall24/semesters/)
-- Spring 2021: [source code](https://github.com/mitmath/18S191/tree/Fall24) and [website](https://computationalthinking.mit.edu/Fall24/semesters/)
+- Spring 2021: [source code](https://github.com/mitmath/18S191/tree/Spring21) and [website](https://computationalthinking.mit.edu/Fall24/semesters/)
 - Fall 2020: [source code](https://github.com/mitmath/18S191/tree/Fall20) and [website](https://computationalthinking.mit.edu/Fall24/semesters/)
 - Spring 2020: [website](https://computationalthinking.mit.edu/Fall24/semesters/)
 - Fall 2019: [source code](https://github.com/dpsanders/6.S083_fall_2019/tree/fall_2019)

--- a/src/_includes/welcome.md
+++ b/src/_includes/welcome.md
@@ -51,7 +51,7 @@ layout: "layout.jlhtml"
                     <p>In literature it’s not enough to just know the technicalities of grammar. In music it’s not enough to learn the scales. The goal is to communicate experiences and emotions. For a computer scientist, it’s not enough to write a working program, the program should be <strong>written with beautiful high level abstractions that speak to your audience</strong>. This class will show you how.</p>
                 </div>
                 <div class="preview">
-                    <img src="https://user-images.githubusercontent.com/6933510/136203632-29ce0a96-5a34-46ad-a996-de55b3bcd380.png" alt="A snippet of Julia code defining a new type called Sphere, with fields 'position', 'radius' and 'index of refration'.">
+                    <img src="https://user-images.githubusercontent.com/6933510/136203632-29ce0a96-5a34-46ad-a996-de55b3bcd380.png" alt="A snippet of Julia code defining a new type called Sphere, with fields 'position', 'radius' and 'index of refraction'.">
                 </div>
             </section>
         </div>


### PR DESCRIPTION
## Summary

- **README.md**: The Spring 2021 source code link incorrectly points to the `Fall24` branch (`https://github.com/mitmath/18S191/tree/Fall24`) instead of the `Spring21` branch. This is likely a copy-paste error from when the Fall 2024 edition was created, as all other semester links correctly point to their respective branches (Fall23, Fall22, Fall20, etc.).
- **src/_includes/welcome.md**: Fix typo "refration" to "refraction" in the alt text of an image describing a Julia `Sphere` type with fields for position, radius, and index of refraction.

## Test plan

- [x] Verify the corrected Spring 2021 link (`https://github.com/mitmath/18S191/tree/Spring21`) resolves to a valid branch
- [x] Verify the alt text now reads "index of refraction" correctly