### PR TITLE
Fix simulate function returning 0 for non-failing components

### DIFF
--- a/src/data_science/simulating_component_failure.jl
+++ b/src/data_science/simulating_component_failure.jl
@@ -329,21 +329,21 @@ Note that does not require (or even allow) methods at first, as some other langu
 Base.rand(X::Binomial) = sum(rand(Bernoulli(X.p)) for i in 1:X.N)
 
 # ╔═╡ 178631ec-8cac-11eb-1117-5d872ba7f66e
-function simulate(N, p)
-	v = fill(0, N, N)
-	t = 0 
-	
-	while any( v .== 0 ) && t < 100
+function simulate(N, p, max_steps=100)
+	v = fill(max_steps, N, N)
+	t = 0
+
+	while any( v .== max_steps ) && t < max_steps
 		t += 1
-		
+
 		for i= 1:N, j=1:N
-			if rand() < p && v[i,j]==0
+			if rand() < p && v[i,j]==max_steps
 				v[i,j] = t
-			end					    
+			end
 		end
-		
+
 	end
-	
+
 	return v
 end
 


### PR DESCRIPTION
## Summary

- Fixes the `simulate` function in `simulating_component_failure.jl` where components that do not fail within the maximum number of time steps were incorrectly assigned a failure time of 0 instead of the maximum time step value.
- Changed the sentinel value from `0` to `max_steps` so non-failing components correctly report `max_steps` as their failure time.
- Added `max_steps` as a configurable parameter with a default of 100, maintaining backward compatibility.

Fixes #154

## Test plan

- [ ] Run the notebook with small `p` values (e.g., `p = 0.01`) and verify that no component shows a failure time of 0.
- [ ] Run with `p = 1.0` to confirm all components still fail at `t = 1`.
- [ ] Verify the heatmap visualization displays correctly with the updated values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)