### PR TITLE
Fix simulate init value for unfailed components

### DIFF
--- a/src/data_science/simulating_component_failure.jl
+++ b/src/data_science/simulating_component_failure.jl
@@ -329,21 +329,21 @@ Note that does not require (or even allow) methods at first, as some other langu
 Base.rand(X::Binomial) = sum(rand(Bernoulli(X.p)) for i in 1:X.N)
 
 # ╔═╡ 178631ec-8cac-11eb-1117-5d872ba7f66e
-function simulate(N, p)
-	v = fill(0, N, N)
-	t = 0 
-	
-	while any( v .== 0 ) && t < 100
+function simulate(N, p, max_steps=100)
+	v = fill(max_steps, N, N)
+	t = 0
+
+	while any( v .== max_steps ) && t < max_steps
 		t += 1
-		
+
 		for i= 1:N, j=1:N
-			if rand() < p && v[i,j]==0
+			if rand() < p && v[i,j]==max_steps
 				v[i,j] = t
-			end					    
+			end
 		end
-		
+
 	end
-	
+
 	return v
 end
 


### PR DESCRIPTION
## Summary
- Fix the `simulate` function in `simulating_component_failure.jl` to initialize the failure-time array with `max_steps` instead of `0`
- Components that never fail (small `p`) now correctly report `max_steps` as their failure time instead of `0`
- Add `max_steps` parameter (default `100`) to replace the hardcoded value, and update all loop conditions to compare against `max_steps`

Fixes #154

## Test plan
- [ ] Run the notebook with small `p` values (e.g. `p = 0.001`) and verify unfailed components show `max_steps` (100) instead of 0
- [ ] Run with `p = 1.0` and verify all components still fail at time 1
- [ ] Verify default behavior is unchanged for typical `p` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)